### PR TITLE
백엔드 - AuthController.java/SignupResponse.java 수정

### DIFF
--- a/backend/src/main/java/com/example/health_care/config/CorsConfig.java
+++ b/backend/src/main/java/com/example/health_care/config/CorsConfig.java
@@ -1,14 +1,14 @@
 package com.example.health_care.config;
 
+import java.util.List;
+
 import org.springframework.context.annotation.Bean;
-import org.springframework.stereotype.Component;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-import java.util.List;
-
-@Component
+@Configuration
 public class CorsConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {

--- a/backend/src/main/java/com/example/health_care/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/health_care/config/SecurityConfig.java
@@ -1,15 +1,9 @@
 package com.example.health_care.config;
 
-import lombok.RequiredArgsConstructor;
-
-import org.springframework.web.filter.CorsFilter;
-
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
-
-import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -17,6 +11,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.filter.CorsFilter;
 
 import com.example.health_care.service.CustomersService;
 

--- a/backend/src/main/java/com/example/health_care/controller/AuthController.java
+++ b/backend/src/main/java/com/example/health_care/controller/AuthController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.example.health_care.dto.LoginRequest;
 import com.example.health_care.dto.LoginResponse;
 import com.example.health_care.dto.SignupRequest;
+import com.example.health_care.dto.SignupResponse;
 import com.example.health_care.entity.CustomersEntity;
 import com.example.health_care.security.JwtTokenProvider;
 import com.example.health_care.service.CustomersService;
@@ -30,22 +31,25 @@ import lombok.extern.slf4j.Slf4j;
 @RequestMapping("/api/auth")
 public class AuthController {
 
-
     private final CustomersService customersService;
     private final AuthenticationManager authenticationManager;
     private final JwtTokenProvider jwtTokenProvider;
 
     @PostMapping("/signup")
-    public ResponseEntity<CustomersEntity> signup(@Valid @RequestBody SignupRequest request) {
-        log.info("[SIGNUP] request id = {}, weight = {}, age = {}, gender = {}, height = {}", request.getId(), request.getWeight(), request.getAge(), request.getGender(), request.getHeight()); // log 확인
+    public ResponseEntity<SignupResponse> signup(@Valid @RequestBody SignupRequest request) {
+        log.info("[SIGNUP] request id = {}, weight = {}, age = {}, gender = {}, height = {}", request.getId(),
+                request.getWeight(), request.getAge(), request.getGender(), request.getHeight()); // log 확인
         CustomersEntity saved = customersService.signup(request);
         log.info("[SIGNUP] saved id = {}", saved.getId()); // log 확인
+
+        // 지금까지는 CustomersEntity를 그대로 반환해서 비밀번호 같은 민감한 정보가 노출됐음
+        // 응답 전용 DTO(SignupResponse)로 변환해서 필요한 데이터만 반환
+        SignupResponse response = SignupResponse.fromEntity(saved);
         return ResponseEntity.created(URI.create("/api/users/" + saved.getId()))
-                .body(saved);
+                .body(response);
     }
 
-
- @PostMapping("/login")
+    @PostMapping("/login")
     public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
         try {
             // 사용자 인증

--- a/backend/src/main/java/com/example/health_care/dto/SignupResponse.java
+++ b/backend/src/main/java/com/example/health_care/dto/SignupResponse.java
@@ -1,5 +1,6 @@
 package com.example.health_care.dto;
 
+import com.example.health_care.entity.CustomersEntity;
 import com.example.health_care.entity.CustomersEntity.Gender;
 import lombok.*;
 
@@ -18,4 +19,16 @@ public class SignupResponse {
     private String accessToken; // JTW
     private String tokenType; // "Bearer"
     private long expiresIn; // 만료 시간(초) <- 추가해두면 프론트가 토큰 관리 편리함.
+
+
+    // AuthController 에서 엔티티를 그대로 반환하지 않고 DTO로 변환하기 위해 추가
+    public static SignupResponse fromEntity(CustomersEntity entity) {
+       return SignupResponse.builder()
+                .id(entity.getId())
+                .weight(entity.getWeight())
+                .age(entity.getAge())
+                .gender(entity.getGender())
+                .height(entity.getHeight())
+                .build();
+    }
 }


### PR DESCRIPTION
회원가입 응답을 엔티티 → DTO(SignupResponse)로 변경

기존 AuthController에서 CustomersEntity 직접 반환하면 비번 같은 민감정보 노출 위험이 있다고 하네요.

-> SignupResponse.fromEntity() 추가, 컨트롤러 응답을 DTO로 변환