### PR TITLE
api.js, authcontext 수정

### DIFF
--- a/frontend/src/config/api.js
+++ b/frontend/src/config/api.js
@@ -1,5 +1,6 @@
 import { Platform, NativeModules } from 'react-native';
 import Constants from 'expo-constants';
+import * as SecureStore from 'expo-secure-store';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 /* ---------- IP/Origin Utils ---------- */
@@ -38,17 +39,13 @@ function pickFirst(...vals) { return vals.find(v => v != null && v !== '') }
 function getDevOrigin() {
   if (ENV_ORIGIN) return ENV_ORIGIN;
 
-  // Emulator/simulator shortcuts
   if (Platform.OS === 'android') {
-    // Android 에뮬레이터가 PC의 localhost 접근할 때
     const host = pickFirst(getHostFromExpo(), getHostFromScriptURL());
     if (!host || !isPrivateIp(host)) {
-      // 에뮬레이터 사용 시 백엔드가 같은 PC에서 돌면 10.0.2.2
       return `http://10.0.2.2:${ENV_PORT}`;
     }
   }
   if (Platform.OS === 'ios') {
-    // iOS 시뮬레이터는 localhost 그대로 접근됨(백엔드가 같은 Mac)
     const host = pickFirst(getHostFromExpo(), getHostFromScriptURL());
     if (!host || !isPrivateIp(host)) {
       return `http://127.0.0.1:${ENV_PORT}`;
@@ -59,12 +56,10 @@ function getDevOrigin() {
   const metroHost = getHostFromScriptURL();
   const host = isPrivateIp(expoHost) ? expoHost : (isPrivateIp(metroHost) ? metroHost : null);
 
-  // 로컬 네트워크 장치(실기기)에서 접속: 개발 PC의 사설 IP나 지정 IP를 한 번에 처리
   const fallbackHost = pickFirst(
     host,
-    EXTRA.devHost,                           // app.json → extra.devHost 지원
-    process.env.EXPO_PUBLIC_DEV_HOST,        // EAS env
-    // ↓ 필요 시 여기 한 줄만 바꿔서 현장 IP 지정
+    EXTRA.devHost,
+    process.env.EXPO_PUBLIC_DEV_HOST,
     '192.168.0.13'
   );
   return `http://${fallbackHost}:${ENV_PORT}`;
@@ -77,18 +72,37 @@ export const API_BASE_DEBUG = ORIGIN;
 /* ---------- Auth Header Handling ---------- */
 let CURRENT_TOKEN = null;
 
+// 토큰 변경 브로드캐스트 (AuthContext가 구독함)
+const tokenListeners = new Set();
+export function subscribeToken(listener) {
+  tokenListeners.add(listener);
+  return () => tokenListeners.delete(listener);
+}
+function emitToken(t) { tokenListeners.forEach(fn => { try { fn(t); } catch {} }); }
+
 function normalizeAuthHeader(raw) {
   if (!raw) return null;
   const v = String(raw).trim();
   return /^(Bearer|Basic|Token)\s+/i.test(v) ? v : `Bearer ${v}`;
 }
-export function setAuthToken(t) { CURRENT_TOKEN = normalizeAuthHeader(t) }
-export function clearAuthToken() { CURRENT_TOKEN = null }
+export async function setAuthToken(t, opts = { persist: false }) {
+  CURRENT_TOKEN = normalizeAuthHeader(t);
+  if (opts.persist && CURRENT_TOKEN) {
+    try { await SecureStore.setItemAsync('accessToken', CURRENT_TOKEN); } catch {}
+  }
+  emitToken(CURRENT_TOKEN);
+}
+export async function clearAuthToken() {
+  CURRENT_TOKEN = null;
+  try { await SecureStore.deleteItemAsync('accessToken'); } catch {}
+  try { await AsyncStorage.multiRemove(['token','authToken','accessToken','@auth/token']); } catch {}
+  emitToken(null);
+}
 
 async function getAuthHeaderObject() {
   if (!CURRENT_TOKEN) {
     try {
-      const raw = await AsyncStorage.getItem('@auth/token');
+      const raw = await SecureStore.getItemAsync('accessToken');
       if (raw) CURRENT_TOKEN = normalizeAuthHeader(raw);
     } catch {}
   }
@@ -97,7 +111,54 @@ async function getAuthHeaderObject() {
   return auth;
 }
 
-/* ---------- Core Fetch ---------- */
+/* ---------- JWT helpers ---------- */
+function safeParseJwt(tokenWithPrefix) {
+  try {
+    const raw = String(tokenWithPrefix || '').replace(/^Bearer\s+/i, '');
+    const payload = raw.split('.')[1];
+    if (!payload) return null;
+    const json = JSON.parse(global.atob ? atob(payload.replace(/-/g, '+').replace(/_/g, '/')) :
+      Buffer.from(payload.replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString('utf8'));
+    return json;
+  } catch { return null; }
+}
+export function isTokenExpiringSoon(token, skewMs = 300000) {
+  const p = safeParseJwt(token);
+  if (!p?.exp) return false;
+  const expiryMs = p.exp * 1000;
+  return expiryMs - Date.now() < skewMs;
+}
+
+/* ---------- Refresh ---------- */
+/** 서버에 /api/auth/refresh 호출해서 새 토큰을 받아 저장 */
+export async function autoRefreshToken() {
+  const auth = await getAuthHeaderObject();
+  if (!auth.Authorization) return null;
+  try {
+    const res = await fetch(`${ORIGIN}/api/auth/refresh`, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        ...auth,
+      },
+      body: '{}',
+    });
+    const text = await res.text();
+    if (!res.ok) throw new Error(text || `HTTP ${res.status}`);
+    const data = JSON.parse(text || '{}');
+    const newToken = data.tokenType ? `${data.tokenType} ${data.token}` : (data.token ?? null);
+    if (!newToken) throw new Error('No token in refresh response');
+    await setAuthToken(newToken, { persist: true });
+    if (__DEV__) console.log('🔄 token refreshed');
+    return newToken;
+  } catch (e) {
+    if (__DEV__) console.warn('🔄 token refresh failed:', e?.message || e);
+    return null;
+  }
+}
+
+/* ---------- Core Fetch (with 401/403 1회 재시도) ---------- */
 const join = (base, path) => `${String(base).replace(/\/+$/, '')}/${String(path).replace(/^\/+/, '')}`;
 
 async function request(method, path, { body, headers, timeoutMs } = {}) {
@@ -105,7 +166,7 @@ async function request(method, path, { body, headers, timeoutMs } = {}) {
   const ctrl = new AbortController();
   const to = setTimeout(() => ctrl.abort(), timeoutMs ?? 25000);
 
-  try {
+  const doFetch = async () => {
     const auth = await getAuthHeaderObject();
     const finalHeaders = {
       Accept: 'application/json',
@@ -113,7 +174,6 @@ async function request(method, path, { body, headers, timeoutMs } = {}) {
       ...(headers || {}),
       ...auth,
     };
-
     if (__DEV__) console.log(`${method}`, url, { headers: finalHeaders, body });
 
     const res = await fetch(url, {
@@ -122,12 +182,24 @@ async function request(method, path, { body, headers, timeoutMs } = {}) {
       signal: ctrl.signal,
       ...(body != null ? { body: typeof body === 'string' ? body : JSON.stringify(body) } : {}),
     });
+    return res;
+  };
+
+  try {
+    let res = await doFetch();
+
+    // 만료/권한 문제 시 한 번만 자동 갱신 + 재시도
+    if (res.status === 401 || res.status === 403) {
+      const refreshed = await autoRefreshToken();
+      if (refreshed) {
+        res = await doFetch();
+      }
+    }
 
     const text = await res.text();
     if (__DEV__) console.log(`${method} <-`, res.status, text);
 
     if (!res.ok) {
-      // 백엔드 에러 바디 그대로 에러 메시지로 노출
       throw new Error(text || `HTTP ${res.status}`);
     }
     try { return JSON.parse(text) } catch { return text }
@@ -144,6 +216,5 @@ export async function apiPost(path, body, init) {
   return request('POST', path, { body, headers: init?.headers, timeoutMs: init?.timeoutMs });
 }
 export async function apiDelete(path, init) {
-  // Spring @DeleteMapping은 보통 쿼리스트링 사용. 바디 보내지 말자.
   return request('DELETE', path, { headers: init?.headers, timeoutMs: init?.timeoutMs });
 }

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -1,134 +1,164 @@
-import { createContext, useContext, useEffect, useState, useMemo } from 'react'
-import * as SecureStore from 'expo-secure-store'
-import AsyncStorage from '@react-native-async-storage/async-storage'
-import { decode as atob } from 'base-64'
-import { apiPost, setAuthToken, clearAuthToken } from '../config/api'
-import { useI18n } from '../i18n/I18nContext' // >>> [ADDED]
+import { createContext, useContext, useEffect, useState, useMemo } from 'react';
+import * as SecureStore from 'expo-secure-store';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { decode as atob } from 'base-64';
+import {
+  apiPost,
+  setAuthToken as setApiAuthToken,
+  clearAuthToken as clearApiAuthToken,
+  isTokenExpiringSoon,
+  autoRefreshToken,
+  subscribeToken,
+} from '../config/api';
+import { useI18n } from '../i18n/I18nContext';
 
-const Ctx = createContext(null)
-export const useAuth = () => useContext(Ctx)
+const Ctx = createContext(null);
+export const useAuth = () => useContext(Ctx);
 
-const goalKey = (userId) => `goalsetup_${String(userId || '').replace(/[^a-zA-Z0-9._-]/g, '_')}`
+const goalKey = (userId) => `goalsetup_${String(userId || '').replace(/[^a-zA-Z0-9._-]/g, '_')}`;
 
 export default function AuthProvider({ children }) {
-  const { t } = useI18n() // >>> [ADDED]
-  const [ready, setReady] = useState(false)
-  const [isAuthenticated, setAuthed] = useState(false)
-  const [user, setUser] = useState(null)
-  const [needsGoalSetup, setNeedsGoalSetup] = useState(false)
-  const [authToken, setAuthTokenState] = useState(null) // 🔥 토큰 상태 추가
+  const { t } = useI18n();
+  const [ready, setReady] = useState(false);
+  const [isAuthenticated, setAuthed] = useState(false);
+  const [user, setUser] = useState(null);
+  const [needsGoalSetup, setNeedsGoalSetup] = useState(false);
+  const [authToken, setAuthTokenState] = useState(null);
 
   const parseJwt = (tokenWithPrefix) => {
     try {
-      const raw = String(tokenWithPrefix || '').replace(/^Bearer\s+/i, '')
-      const payload = raw.split('.')[1]
-      const json = JSON.parse(atob(payload.replace(/-/g, '+').replace(/_/g, '/')))
-      return json || {}
-    } catch { return {} }
-  }
+      const raw = String(tokenWithPrefix || '').replace(/^Bearer\s+/i, '');
+      const payload = raw.split('.')[1];
+      const json = JSON.parse(atob(payload.replace(/-/g, '+').replace(/_/g, '/')));
+      return json || {};
+    } catch { return {}; }
+  };
 
   const loadGoalFlag = async (userId) => {
-    if (!userId) return false
-    const v = await SecureStore.getItemAsync(goalKey(userId))
-    return v !== '1'
-  }
+    if (!userId) return false;
+    const v = await SecureStore.getItemAsync(goalKey(userId));
+    return v !== '1';
+  };
 
   const wipeLegacyTokens = async () => {
-    try { await AsyncStorage.multiRemove(['token','authToken','accessToken','@auth/token']) } catch {}
-  }
+    try { await AsyncStorage.multiRemove(['token','authToken','accessToken','@auth/token']); } catch {}
+  };
 
+  // api.js가 토큰을 갱신했을 때 로컬 state 동기화
   useEffect(() => {
-    let mounted = true
-    ;(async () => {
+    const unsub = subscribeToken((next) => setAuthTokenState(next));
+    return unsub;
+  }, []);
+
+  // 초기 부팅: 토큰 있으면 검증하고 필요 시 즉시 갱신
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
       try {
-        await wipeLegacyTokens()
-        const token = await SecureStore.getItemAsync('accessToken')
-        if (!mounted) return
-        if (token) {
-          setAuthToken(token)
-          setAuthTokenState(token) // 🔥 토큰 상태 설정
-          let uid = null
-          try { uid = parseJwt(token).sub ?? null } catch {}
-          if (!mounted) return
-          setUser({ id: uid })
-          setAuthed(true)
-          try { await AsyncStorage.setItem('last_user_id', String(uid || '')) } catch {}
+        await wipeLegacyTokens();
+
+        const stored = await SecureStore.getItemAsync('accessToken');
+        if (!mounted) return;
+
+        if (stored) {
+          setApiAuthToken(stored);
+          setAuthTokenState(stored);
+
+          // 만료 임박 시 즉시 갱신 시도
+          let workingToken = stored;
+          if (isTokenExpiringSoon(stored, 60_000)) {
+            const refreshed = await autoRefreshToken();
+            if (refreshed) workingToken = refreshed;
+          }
+
+          let uid = null;
+          try { uid = parseJwt(workingToken).sub ?? null; } catch {}
+          if (!mounted) return;
+
+          setUser({ id: uid });
+          setAuthed(true);
+          try { await AsyncStorage.setItem('last_user_id', String(uid || '')); } catch {}
           try {
-            const need = await loadGoalFlag(uid)
-            if (mounted) setNeedsGoalSetup(need)
+            const need = await loadGoalFlag(uid);
+            if (mounted) setNeedsGoalSetup(need);
           } catch {}
         }
-      } catch (e) {
+      } catch {
       } finally {
-        if (mounted) setReady(true)
+        if (mounted) setReady(true);
       }
-    })()
-    return () => { mounted = false }
-  }, [])
+    })();
+    return () => { mounted = false; };
+  }, []);
+
+  // 주기적 사전 체크(1분마다, 5분 이내 만료면 갱신)
+  useEffect(() => {
+    if (!authToken) return;
+    const timer = setInterval(async () => {
+      try {
+        if (isTokenExpiringSoon(authToken, 5 * 60_000)) {
+          await autoRefreshToken();
+        }
+      } catch {}
+    }, 60_000);
+    return () => clearInterval(timer);
+  }, [authToken]);
 
   const login = async (id, password) => {
     try {
-      const res = await apiPost('/api/auth/login', { id, password })
+      const res = await apiPost('/api/auth/login', { id, password });
+      const token = res.tokenType ? `${res.tokenType} ${res.token}` : `Bearer ${res.token}`;
 
-      // tokenType 이 있으면 그대로 사용, 없으면 기본 Bearer 사용
-      const token = res.tokenType ? `${res.tokenType} ${res.token}` : `Bearer ${res.token}`
+      await SecureStore.setItemAsync('accessToken', token);
+      await wipeLegacyTokens();
+      await setApiAuthToken(token, { persist: false }); // 이미 SecureStore에 저장함
+      setAuthTokenState(token);
 
-       if (__DEV__) {
-        console.log(' 로그인 응답:', res)
-        console.log(' 저장할 토큰:', token)
-       }
+      const userId = res.id ?? parseJwt(token).sub ?? id;
+      setUser({ id: userId });
+      setAuthed(true);
 
-      // 토큰 저장
-      await SecureStore.setItemAsync('accessToken', token)
-      await wipeLegacyTokens()
-      setAuthToken(token)
-      setAuthTokenState(token) // 🔥 토큰 상태 설정
-
-      // 유저 정보 파싱
-      const userId = res.id ?? parseJwt(token).sub ?? id
-       if (__DEV__) {
-         console.log(' 파싱된 userId:', userId)
-         console.log(' JWT Payload:', parseJwt(token))
-       }
-      setUser({ id: userId })
-      setAuthed(true)
-
-      try { await AsyncStorage.setItem('last_user_id', String(userId)) 
-      } catch {}
-      setNeedsGoalSetup(await loadGoalFlag(userId))
-      return true
+      try { await AsyncStorage.setItem('last_user_id', String(userId)); } catch {}
+      setNeedsGoalSetup(await loadGoalFlag(userId));
+      return true;
     } catch (e) {
-      // 401/인증 실패 에러 메시지 매핑
-      const msg = String(e?.message || '')
+      const msg = String(e?.message || '');
       if (msg.includes('401') || /Invalid credentials|Unauthorized/i.test(msg)) {
-        throw new Error(t('INVALID_CREDENTIALS'))
+        throw new Error(t('INVALID_CREDENTIALS'));
       }
-      throw e
+      throw e;
     }
-  }
+  };
 
   const logout = async () => {
-    try { await apiPost('/api/auth/logout', {}) } catch {}
-    try { await SecureStore.deleteItemAsync('accessToken') } catch {}
-    await wipeLegacyTokens()
-    try { await AsyncStorage.removeItem('last_user_id') } catch {}
-    clearAuthToken()
-    setAuthTokenState(null) // 🔥 토큰 상태 초기화
-    setUser(null)
-    setAuthed(false)
-    setNeedsGoalSetup(false)
-  }
+    try { await apiPost('/api/auth/logout', {}); } catch {}
+    try { await SecureStore.deleteItemAsync('accessToken'); } catch {}
+    await wipeLegacyTokens();
+    try { await AsyncStorage.removeItem('last_user_id'); } catch {}
+    await clearApiAuthToken();
+    setUser(null);
+    setAuthed(false);
+    setNeedsGoalSetup(false);
+    setAuthTokenState(null);
+  };
 
   const markGoalDone = async () => {
-    const uid = user?.id
-    if (!uid) return
-    await SecureStore.setItemAsync(goalKey(uid), '1')
-    setNeedsGoalSetup(false)
-  }
+    const uid = user?.id;
+    if (!uid) return;
+    await SecureStore.setItemAsync(goalKey(uid), '1');
+    setNeedsGoalSetup(false);
+  };
 
-  const value = useMemo(() => ({ 
-    ready, isAuthenticated, user, needsGoalSetup, login, logout, markGoalDone, token: authToken,
-  }), [ready, isAuthenticated, user, needsGoalSetup, authToken])
+  const value = useMemo(() => ({
+    ready,
+    isAuthenticated,
+    user,
+    needsGoalSetup,
+    login,
+    logout,
+    markGoalDone,
+    token: authToken,
+  }), [ready, isAuthenticated, user, needsGoalSetup, authToken]);
 
-  return <Ctx.Provider value={value}>{children}</Ctx.Provider>
+  return <Ctx.Provider value={value}>{children}</Ctx.Provider>;
 }


### PR DESCRIPTION


api.js

/api/auth/refresh 호출하는 autoRefreshToken() 추가.

401/403 응답 시 한 번만 자동 갱신 후 재시도.

JWT 파싱으로 “만료 임박” 판정(isTokenExpiringSoon).

토큰 변경을 브로드캐스트하는 subscribeToken() 제공 → AuthContext와 동기화.

setAuthToken, clearAuthToken이 listener에 알림.

AuthContext.jsx

앱 시작 시 저장 토큰 불러오고 만료 임박이면 즉시 갱신.

1분 주기로 체크해서 5분 이내 만료면 자동 갱신.

api.js의 토큰 변경 이벤트를 구독해서 상태 일관성 유지.

백엔드의 refresh 엔드포인트는 POST /api/auth/refresh로 가정했어. 응답은 { tokenType, token } 혹은 { token } 형태. 만약 경로나 필드명이 다르면 그 두 군데만 바꿔주면 끝이야:

api.js의 autoRefreshToken() 안 URL/필드

